### PR TITLE
Removed duplicate import in packages.config

### DIFF
--- a/IdentityServer3.Admin/Host/packages.config
+++ b/IdentityServer3.Admin/Host/packages.config
@@ -11,5 +11,4 @@
   <package id="Owin" version="1.0" targetFramework="net451" />
   <package id="System.IdentityModel.Tokens.Jwt" version="4.0.2.202250711" targetFramework="net45" />
   <package id="Thinktecture.IdentityServer3" version="1.4.1" targetFramework="net45" />
-  <package id="AutoMapper" version="4.0.4" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
<package id="AutoMapper" version="4.0.4" targetFramework="net45" />

This will allow the solution to build without seeing nuget errors.